### PR TITLE
Fix unmutable audio feedback

### DIFF
--- a/src/entity/CaptureStream.ts
+++ b/src/entity/CaptureStream.ts
@@ -97,8 +97,10 @@ export class CaptureStream {
 
     original.srcObject = this.mediaStream;
     original.play();
+    original.muted = true;
     preview.srcObject = this.previewStream;
     preview.play();
+    preview.muted = true;
 
     this.shutter = new Shutter({ original, preview });
     return this.shutter;


### PR DESCRIPTION
2 virtual `<video/>` elements are created internally that are used for recording, but they weren't set to mute, causing audio feedback.