### PR TITLE
Better source selection

### DIFF
--- a/src/entity/CaptureSource.ts
+++ b/src/entity/CaptureSource.ts
@@ -1,0 +1,9 @@
+export class CaptureSource {
+  device: MediaDeviceInfo;
+  label: string;
+
+  constructor({ device, label }: { device: MediaDeviceInfo; label: string }) {
+    this.device = device;
+    this.label = label || "Unnamed source";
+  }
+}

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -1,3 +1,4 @@
+export * from "./CaptureSource";
 export * from "./CaptureStream";
 export * from "./Shutter";
 export * from "./Recorder";

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,9 +1,5 @@
-import { CaptureStream } from "../entity";
-import {
-  CaptureSource,
-  StorageMethod,
-  FallbackMediaRecorderConfig
-} from "../types";
+import { CaptureStream, CaptureSource } from "../entity";
+import { StorageMethod, FallbackMediaRecorderConfig } from "../types";
 import settings from "../main/settings";
 import { requestAndCloseStream } from "../util";
 
@@ -29,10 +25,20 @@ export async function getDevices(
   devices.forEach(device => {
     switch (device.kind) {
       case "videoinput":
-        video.push({ device, label: device.label || "Unnamed video input" });
+        video.push(
+          new CaptureSource({
+            device,
+            label: device.label || "Unnamed video input"
+          })
+        );
         break;
       case "audioinput":
-        audio.push({ device, label: device.label || "Unnamed audio input" });
+        audio.push(
+          new CaptureSource({
+            device,
+            label: device.label || "Unnamed audio input"
+          })
+        );
         break;
       default:
         console.log("Other input type detected:", device.kind);
@@ -44,6 +50,9 @@ export async function getDevices(
 
 /**
  * Creates capture stream via chosen CaptureSource's
+ * @param {Object} [opts]
+ * @param {CaptureSource | "front" | "back"} [opts.video] - Video source to create CaptureStream from
+ * @param {CaptureSource} [opts.video] - Audio source to create CaptureStream from
  * @returns {Promise<CaptureStream>} Freshly created CaptureStream from sources
  */
 export async function createCaptureStream({
@@ -51,7 +60,7 @@ export async function createCaptureStream({
   audio,
   fallbackConfig
 }: {
-  video?: CaptureSource;
+  video?: CaptureSource | "front" | "back";
   audio?: CaptureSource;
   fallbackConfig?: Partial<FallbackMediaRecorderConfig>;
 }) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,3 @@
-export type CaptureSource = {
-  device: MediaDeviceInfo;
-  label: string;
-};
-
 export type StorageMethod = "localStorage" | "sessionStorage" | null;
 
 export type CKSettings = {

--- a/src/util/stream.ts
+++ b/src/util/stream.ts
@@ -1,3 +1,5 @@
+import { CaptureSource } from "../entity";
+
 export async function closeStream(stream: MediaStream): Promise<void> {
   stream.getVideoTracks().forEach(track => track.stop());
   stream.getAudioTracks().forEach(track => track.stop());
@@ -32,4 +34,36 @@ export function getVideoSpecs(
   }
 
   return null;
+}
+
+export function toTrackConstraints(
+  input: CaptureSource | MediaTrackConstraints | "front" | "back" | undefined
+): MediaTrackConstraints {
+  if (input === undefined) {
+    return {};
+  }
+
+  if (typeof input === "string") {
+    if (!["front", "back"].includes(input)) {
+      throw new Error(`Unknown media selector: ${input}`);
+    }
+
+    return {
+      facingMode: input === "front" ? "user" : "environment"
+    };
+  }
+
+  if (input instanceof CaptureSource) {
+    return {
+      deviceId: {
+        exact: input.device.deviceId
+      }
+    };
+  }
+
+  if (input instanceof Object) {
+    return input;
+  }
+
+  return {};
 }


### PR DESCRIPTION
### Changes:

- Fix Safari being unable to start with front-facing camera.
- Fix Safari source selection erroring out.
- Fix Safari not displaying source names.
- Create media streams from things other than `CaptureSource`'s.

(Fixes may also apply to other browsers)

### Code change summary

- Media permission confirmation modal will pop up by default on `getDevices` call.
- Better matching when not using enhanced `getDevices` call.
- New helper function to parse various sources to `MediaTrackConstraint`'s.
- `CaptureSource` is now a class.